### PR TITLE
Add insecure TLS option for HTTP

### DIFF
--- a/cmd/yapi/main.go
+++ b/cmd/yapi/main.go
@@ -71,6 +71,7 @@ type rootCommand struct {
 	urlOverride  string
 	noColor      bool
 	binaryOutput bool
+	insecure     bool
 	httpClient   *http.Client
 	engine       *core.Engine
 }
@@ -157,6 +158,7 @@ func main() {
 		app.urlOverride = cfg.URLOverride
 		app.noColor = cfg.NoColor
 		app.binaryOutput = cfg.BinaryOutput
+		app.insecure = cfg.Insecure
 		color.SetNoColor(app.noColor)
 	}
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
@@ -209,7 +211,13 @@ func (app *rootCommand) watchE(cmd *cobra.Command, args []string) error {
 	usePretty := pretty || (fromTUI && !noPretty)
 
 	if usePretty {
-		return tui.RunWatch(path)
+		opts := runner.Options{
+			URLOverride:  app.urlOverride,
+			NoColor:      app.noColor,
+			BinaryOutput: app.binaryOutput,
+			Insecure:     app.insecure,
+		}
+		return tui.RunWatch(path, opts)
 	}
 	return app.watchConfigPath(path, envName)
 }
@@ -310,6 +318,7 @@ func (app *rootCommand) executeRunE(ctx runContext) error {
 		URLOverride:  app.urlOverride,
 		NoColor:      app.noColor,
 		BinaryOutput: app.binaryOutput,
+		Insecure:     app.insecure,
 	}
 
 	// Load project and environment configuration

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -10,6 +10,7 @@ type Config struct {
 	URLOverride  string
 	NoColor      bool
 	BinaryOutput bool
+	Insecure     bool
 	Environment  string // Target environment from project config
 }
 
@@ -52,6 +53,7 @@ func BuildRoot(cfg *Config, handlers *Handlers) *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&cfg.URLOverride, "url", "u", "", "Override the URL specified in the config file")
 	rootCmd.PersistentFlags().BoolVar(&cfg.NoColor, "no-color", false, "Disable color output")
 	rootCmd.PersistentFlags().BoolVar(&cfg.BinaryOutput, "binary-output", false, "Display binary content to stdout (by default binary content is hidden)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Insecure, "insecure", false, "Skip TLS verification for HTTPS requests; use insecure transport for gRPC")
 
 	// Build commands from manifest
 	for _, spec := range cmdManifest {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -87,6 +87,7 @@ func Compile(cfg *config.ConfigV1, resolver vars.Resolver) *CompiledRequest {
 	// 6. Protocol Detection and Validation
 	transport := domain.DetectTransport(req.URL, interpolated.Graphql != "")
 	req.Metadata["transport"] = transport
+	req.Metadata["insecure"] = fmt.Sprintf("%t", interpolated.Insecure)
 
 	switch transport {
 	case constants.TransportGRPC:
@@ -100,7 +101,6 @@ func Compile(cfg *config.ConfigV1, resolver vars.Resolver) *CompiledRequest {
 		req.Metadata["rpc"] = interpolated.RPC
 		req.Metadata["proto"] = interpolated.Proto
 		req.Metadata["proto_path"] = interpolated.ProtoPath
-		req.Metadata["insecure"] = fmt.Sprintf("%t", interpolated.Insecure)
 		req.Metadata["plaintext"] = fmt.Sprintf("%t", interpolated.Plaintext)
 
 	case constants.TransportTCP:

--- a/internal/config/v1.go
+++ b/internal/config/v1.go
@@ -84,7 +84,7 @@ type ConfigV1 struct {
 	Data           string            `yaml:"data,omitempty"`     // TCP raw data
 	Encoding       string            `yaml:"encoding,omitempty"` // text, hex, base64
 	JQFilter       string            `yaml:"jq_filter,omitempty"`
-	Insecure       bool              `yaml:"insecure,omitempty"`     // For gRPC
+	Insecure       bool              `yaml:"insecure,omitempty"`     // Skip TLS verification for HTTP/GraphQL; uses insecure transport for gRPC
 	Plaintext      bool              `yaml:"plaintext,omitempty"`    // For gRPC
 	ReadTimeout    int               `yaml:"read_timeout,omitempty"` // TCP read timeout in seconds
 	IdleTimeout    int               `yaml:"idle_timeout,omitempty"` // TCP idle timeout in milliseconds (default 500)
@@ -427,6 +427,7 @@ func (c *ConfigV1) buildURL() string {
 func (c *ConfigV1) enrichMetadata(req *domain.Request) error {
 	transport := domain.DetectTransport(c.URL, c.Graphql != "")
 	req.Metadata["transport"] = transport
+	req.Metadata["insecure"] = fmt.Sprintf("%t", c.Insecure)
 
 	switch transport {
 	case constants.TransportGRPC:
@@ -434,7 +435,6 @@ func (c *ConfigV1) enrichMetadata(req *domain.Request) error {
 		req.Metadata["rpc"] = c.RPC
 		req.Metadata["proto"] = c.Proto
 		req.Metadata["proto_path"] = c.ProtoPath
-		req.Metadata["insecure"] = fmt.Sprintf("%t", c.Insecure)
 		req.Metadata["plaintext"] = fmt.Sprintf("%t", c.Plaintext)
 	case constants.TransportTCP:
 		req.Metadata["data"] = c.Data

--- a/internal/langserver/langserver.go
+++ b/internal/langserver/langserver.go
@@ -441,7 +441,7 @@ var topLevelKeys = []struct {
 	{"data", "Raw data for TCP requests"},
 	{"encoding", "Data encoding (text, hex, base64)"},
 	{"jq_filter", "JQ filter to apply to response"},
-	{"insecure", "Skip TLS verification (boolean)"},
+	{"insecure", "Skip TLS verification for HTTP/GraphQL; use insecure transport for gRPC (boolean)"},
 	{"plaintext", "Use plaintext gRPC (boolean)"},
 	{"read_timeout", "TCP read timeout in seconds"},
 	{"close_after_send", "Close TCP connection after sending (boolean)"},

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -35,6 +35,7 @@ type Options struct {
 	URLOverride  string
 	NoColor      bool
 	BinaryOutput bool
+	Insecure     bool
 	EnvOverrides map[string]string // Environment variables from project config
 	ProjectRoot  string            // Path to project root (for validation)
 	ProjectEnv   string            // Selected environment name (for validation)
@@ -42,6 +43,13 @@ type Options struct {
 
 // Run executes a yapi request and returns the result.
 func Run(ctx context.Context, exec executor.TransportFunc, req *domain.Request, warnings []string, opts Options) (*Result, error) {
+	if opts.Insecure {
+		if req.Metadata == nil {
+			req.Metadata = make(map[string]string)
+		}
+		req.Metadata["insecure"] = "true"
+	}
+
 	// Apply URL override
 	if opts.URLOverride != "" {
 		req.URL = opts.URLOverride


### PR DESCRIPTION
First of all, thanks for yapi, I love it :-)
I'm starting to use it in my projects, but when testing locally I'm using self-signed certificates, so I needed this feature myself

## Description
Per-request and global support for skipping TLS verification on HTTP/GraphQL requests.

- Adds --insecure CLI flag to force insecure TLS for HTTPS requests (also enables gRPC insecure transport).
- Uses the existing insecure field in request YAML to skip certificate verification for HTTP/GraphQL.
- HTTP transport now clones the base TLS config and sets InsecureSkipVerify when requested.
- Wires flag support through run/watch/test/stress execution paths, updates LSP hint, and includes TLS behavior tests.

Usage example:

```
yapi: v1
url: https://localhost:8443
method: GET
insecure: true
```

CLI: `yapi run --insecure path/to/request.yapi.yml`
