### PR TITLE
Support request body files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ yapi send https://jsonplaceholder.typicode.com/posts/1
 # POST with JSON body (method auto-detected when body is provided)
 yapi send https://httpbin.org/post '{"title":"Hello from yapi"}'
 
+# POST with body from file
+yapi send https://httpbin.org/post --body-file ./payload.json \
+  -H 'Content-Type: application/json'
+
 # Explicit method, custom headers
 yapi send -X PUT https://httpbin.org/put '{"updated":true}' \
   -H 'Authorization: Bearer my-token'
@@ -161,6 +165,7 @@ yapi send 'tcp://tcpbin.com:4242' 'Hello from yapi!'
 **Flags:**
 - `-X, --method` - HTTP method (default: GET, or POST if body is provided)
 - `-H, --header` - Custom headers (repeatable, e.g. `-H 'Key: Value'`)
+- `--body-file` - Read request body from a file
 - `-v, --verbose` - Show request details, timing, and response headers
 - `--json` - Output full result as JSON with metadata
 - `--jq` - Apply a JQ filter to the response
@@ -269,6 +274,16 @@ body:
   tags:
     - cli
     - testing
+```
+
+For larger or generated payloads, keep the body in a separate file:
+
+```yaml
+yapi: v1
+url: https://api.example.com/posts
+method: POST
+content_type: application/json
+body_file: ./fixtures/create-post.json
 ```
 
 ### 4\. Advanced Assertions

--- a/cli/cmd/yapi/send.go
+++ b/cli/cmd/yapi/send.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,6 +28,10 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	jqFilter, _ := cmd.Flags().GetString("jq")
+	bodyFile, _ := cmd.Flags().GetString("body-file")
+	if body != "" && bodyFile != "" {
+		return fmt.Errorf("positional body and --body-file are mutually exclusive")
+	}
 
 	log := NewLogger(verbose)
 
@@ -33,9 +39,10 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	transport := domain.DetectTransport(url, false)
 
 	// Default method: POST if body provided, GET otherwise (HTTP only)
+	bodyProvided := body != "" || bodyFile != ""
 	if method == "" {
 		if transport == constants.TransportHTTP {
-			if body != "" {
+			if bodyProvided {
 				method = constants.MethodPOST
 			} else {
 				method = constants.MethodGET
@@ -63,6 +70,7 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Set body
+	bodyLog := body
 	if body != "" {
 		req.Body = strings.NewReader(body)
 
@@ -77,6 +85,15 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+	if bodyFile != "" {
+		bodyBytes, err := os.ReadFile(bodyFile) // #nosec G304 -- body-file is an explicit user-provided request payload path
+		if err != nil {
+			return fmt.Errorf("failed to read body-file %q: %w", bodyFile, err)
+		}
+		req.Body = bytes.NewReader(bodyBytes)
+		req.Metadata["body_source"] = "body_file"
+		bodyLog = fmt.Sprintf("<body_file: %s (%d bytes)>", bodyFile, len(bodyBytes))
+	}
 
 	// Set transport metadata
 	req.Metadata["transport"] = transport
@@ -86,7 +103,9 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 
 	// TCP-specific metadata defaults
 	if transport == constants.TransportTCP {
-		req.Metadata["data"] = body
+		if bodyFile == "" {
+			req.Metadata["data"] = body
+		}
 		req.Metadata["encoding"] = "text"
 		req.Metadata["read_timeout"] = "5"
 		req.Metadata["idle_timeout"] = "500"
@@ -98,7 +117,7 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Verbose("Transport: %s", transport)
-	log.Request(method, url, req.Headers, body)
+	log.Request(method, url, req.Headers, bodyLog)
 
 	// Get executor
 	exec, err := executor.GetTransport(transport, app.httpClient)

--- a/cli/internal/cli/commands/commands.go
+++ b/cli/internal/cli/commands/commands.go
@@ -177,6 +177,7 @@ var cmdManifest = []CommandSpec{
 		Flags: []FlagSpec{
 			{Name: "method", Shorthand: "X", Type: "string", Default: "", Usage: "HTTP method (default: GET, or POST if body is provided)"},
 			{Name: "header", Shorthand: "H", Type: "stringSlice", Default: nil, Usage: "Custom headers (e.g. -H 'Content-Type: application/json')"},
+			{Name: "body-file", Type: "string", Default: "", Usage: "Read request body from a file"},
 			{Name: "verbose", Shorthand: "v", Type: "bool", Default: false, Usage: "Show verbose output (request details, timing, headers)"},
 			{Name: "json", Type: "bool", Default: false, Usage: "Output result as JSON with full metadata"},
 			{Name: "jq", Type: "string", Default: "", Usage: "JQ filter to apply to the response"},

--- a/cli/internal/cli/commands/commands_test.go
+++ b/cli/internal/cli/commands/commands_test.go
@@ -98,6 +98,24 @@ func TestBuildRoot(t *testing.T) {
 	}
 }
 
+func TestSendCommandHasBodyFileFlag(t *testing.T) {
+	var sendSpec *CommandSpec
+	for i, spec := range cmdManifest {
+		if spec.Use == "send <url> [body]" {
+			sendSpec = &cmdManifest[i]
+			break
+		}
+	}
+	if sendSpec == nil {
+		t.Fatal("send command not found in manifest")
+	}
+
+	cmd := BuildCommand(*sendSpec)
+	if cmd.Flags().Lookup("body-file") == nil {
+		t.Fatal("send command missing body-file flag")
+	}
+}
+
 // Helper function to find a command by name
 func findCommandByName(root *cobra.Command, name string) *cobra.Command {
 	for _, cmd := range root.Commands() {

--- a/cli/internal/config/loader.go
+++ b/cli/internal/config/loader.go
@@ -100,6 +100,7 @@ func parseV1WithOptions(data []byte, configPath string, resolver vars.Resolver, 
 	if err := yaml.Unmarshal(data, &v1); err != nil {
 		return nil, err
 	}
+	v1.configPath = configPath
 
 	// Merge with environment defaults if provided
 	if defaults != nil {

--- a/cli/internal/config/loader_test.go
+++ b/cli/internal/config/loader_test.go
@@ -171,6 +171,64 @@ headers:
 	}
 }
 
+func TestLoadFromStringWithPath_BodyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.MkdirAll(tmpDir+"/fixtures", 0750); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"name":"from-file","enabled":true}`
+	if err := os.WriteFile(tmpDir+"/fixtures/payload.json", []byte(payload), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	yapiContent := `yapi: v1
+url: https://example.com/create
+method: POST
+content_type: application/json
+body_file: fixtures/payload.json`
+	yapiPath := tmpDir + "/request.yapi.yml"
+
+	result, err := LoadFromStringWithPath(yapiContent, yapiPath, nil, nil)
+	if err != nil {
+		t.Fatalf("LoadFromStringWithPath() failed: %v", err)
+	}
+	if result == nil || result.Request == nil {
+		t.Fatal("LoadFromStringWithPath() returned nil result or request")
+	}
+
+	bodyBytes, err := io.ReadAll(result.Request.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	if string(bodyBytes) != payload {
+		t.Errorf("body = %q, want %q", string(bodyBytes), payload)
+	}
+	if result.Request.Headers["Content-Type"] != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", result.Request.Headers["Content-Type"])
+	}
+	if result.Request.Metadata["body_source"] != "body_file" {
+		t.Errorf("body_source = %q, want body_file", result.Request.Metadata["body_source"])
+	}
+}
+
+func TestLoadFromStringWithPath_BodyFileMutuallyExclusive(t *testing.T) {
+	tmpDir := t.TempDir()
+	yapiContent := `yapi: v1
+url: https://example.com/create
+method: POST
+body_file: payload.json
+json: '{"name":"inline"}'`
+
+	_, err := LoadFromStringWithPath(yapiContent, tmpDir+"/request.yapi.yml", nil, nil)
+	if err == nil {
+		t.Fatal("LoadFromStringWithPath() should have failed")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive error", err)
+	}
+}
+
 func TestLoadFromStringWithPath_EnvFiles_MultipleFiles(t *testing.T) {
 	// Create a temporary directory for our test files
 	tmpDir, err := os.MkdirTemp("", "yapi-envfiles-multi-test-*")

--- a/cli/internal/config/v1.go
+++ b/cli/internal/config/v1.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"mime/multipart"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -26,6 +28,7 @@ var knownV1Keys = map[string]bool{
 	"content_type":     true,
 	"headers":          true,
 	"body":             true,
+	"body_file":        true,
 	"json":             true,
 	"form":             true,
 	"query":            true,
@@ -74,8 +77,9 @@ type ConfigV1 struct {
 	ContentType    string            `yaml:"content_type,omitempty"`
 	Headers        map[string]string `yaml:"headers,omitempty"`
 	Body           map[string]any    `yaml:"body,omitempty"`
-	JSON           string            `yaml:"json,omitempty"` // Raw JSON override
-	Form           map[string]string `yaml:"form,omitempty"` // Form data (application/x-www-form-urlencoded or multipart/form-data)
+	BodyFile       string            `yaml:"body_file,omitempty"` // Path to raw request body file
+	JSON           string            `yaml:"json,omitempty"`      // Raw JSON override
+	Form           map[string]string `yaml:"form,omitempty"`      // Form data (application/x-www-form-urlencoded or multipart/form-data)
 	Query          map[string]string `yaml:"query,omitempty"`
 	Graphql        string            `yaml:"graphql,omitempty"`   // GraphQL query/mutation
 	Variables      map[string]any    `yaml:"variables,omitempty"` // GraphQL variables
@@ -110,6 +114,8 @@ type ConfigV1 struct {
 
 	// Chain allows executing multiple dependent requests
 	Chain []ChainStep `yaml:"chain,omitempty"`
+
+	configPath string `yaml:"-"` // Path to this config file for resolving relative files
 }
 
 // WaitFor defines polling behavior for a request
@@ -146,6 +152,7 @@ func (c *ConfigV1) Merge(step ChainStep) ConfigV1 {
 	m.Path = utils.Coalesce(step.Path, c.Path)
 	m.Method = utils.Coalesce(step.Method, c.Method)
 	m.ContentType = utils.Coalesce(step.ContentType, c.ContentType)
+	m.BodyFile = utils.Coalesce(step.BodyFile, c.BodyFile)
 	m.JSON = utils.Coalesce(step.JSON, c.JSON)
 	m.Graphql = utils.Coalesce(step.Graphql, c.Graphql)
 	m.Service = utils.Coalesce(step.Service, c.Service)
@@ -204,6 +211,7 @@ func (c *ConfigV1) MergeWithDefaults(defaults ConfigV1) ConfigV1 {
 	m.Path = utils.Coalesce(c.Path, defaults.Path)
 	m.Method = utils.Coalesce(c.Method, defaults.Method)
 	m.ContentType = utils.Coalesce(c.ContentType, defaults.ContentType)
+	m.BodyFile = utils.Coalesce(c.BodyFile, defaults.BodyFile)
 	m.JSON = utils.Coalesce(c.JSON, defaults.JSON)
 	m.Graphql = utils.Coalesce(c.Graphql, defaults.Graphql)
 	m.Service = utils.Coalesce(c.Service, defaults.Service)
@@ -256,6 +264,7 @@ func (c *ConfigV1) MergeWithDefaults(defaults ConfigV1) ConfigV1 {
 	if len(c.EnvFiles) > 0 {
 		m.EnvFiles = c.EnvFiles
 	}
+	m.configPath = c.configPath
 
 	return m
 }
@@ -366,6 +375,9 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 	if c.JSON != "" {
 		bodyFieldCount++
 	}
+	if c.BodyFile != "" {
+		bodyFieldCount++
+	}
 	if len(c.Body) > 0 {
 		bodyFieldCount++
 	}
@@ -373,7 +385,7 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 		bodyFieldCount++
 	}
 	if bodyFieldCount > 1 {
-		return nil, "", fmt.Errorf("`body`, `json`, and `form` are mutually exclusive")
+		return nil, "", fmt.Errorf("`body`, `body_file`, `json`, and `form` are mutually exclusive")
 	}
 
 	// Handle JSON string
@@ -382,6 +394,16 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 			c.ContentType = "application/json"
 		}
 		return strings.NewReader(c.JSON), "json", nil
+	}
+
+	// Handle raw body file
+	if c.BodyFile != "" {
+		bodyPath := c.resolveConfigRelativePath(c.BodyFile)
+		bodyBytes, err := os.ReadFile(bodyPath) // #nosec G304 -- body_file is an explicit user-provided request payload path
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read body_file %q: %w", c.BodyFile, err)
+		}
+		return bytes.NewReader(bodyBytes), "body_file", nil
 	}
 
 	// Handle JSON object
@@ -432,6 +454,13 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 	}
 
 	return nil, "", nil
+}
+
+func (c *ConfigV1) resolveConfigRelativePath(path string) string {
+	if path == "" || filepath.IsAbs(path) || c.configPath == "" {
+		return path
+	}
+	return filepath.Join(filepath.Dir(c.configPath), path)
 }
 
 // buildURL constructs the final URL with path and query parameters

--- a/cli/internal/langserver/langserver.go
+++ b/cli/internal/langserver/langserver.go
@@ -437,6 +437,7 @@ var topLevelKeys = []struct {
 	{"headers", "HTTP headers as key-value pairs"},
 	{"content_type", "Content-Type header value"},
 	{"body", "Request body as key-value pairs"},
+	{"body_file", "Path to a raw request body file"},
 	{"json", "Raw JSON string for request body"},
 	{"query", "Query parameters as key-value pairs"},
 	{"graphql", "GraphQL query or mutation (multiline string)"},

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -467,6 +467,9 @@ func logResolvedConfig(stepNum int, stepName string, cfg *config.ConfigV1) {
 	if cfg.JSON != "" {
 		fmt.Fprintf(os.Stderr, "[VERBOSE]   JSON: %s\n", truncateStr(cfg.JSON))
 	}
+	if cfg.BodyFile != "" {
+		fmt.Fprintf(os.Stderr, "[VERBOSE]   BodyFile: %s\n", cfg.BodyFile)
+	}
 	if cfg.Data != "" {
 		fmt.Fprintf(os.Stderr, "[VERBOSE]   Data: %s\n", truncateStr(cfg.Data))
 	}
@@ -496,6 +499,7 @@ func warnBareChainRefsInConfig(stepName string, cfg *config.ConfigV1) {
 	check("url", cfg.URL)
 	check("path", cfg.Path)
 	check("json", cfg.JSON)
+	check("body_file", cfg.BodyFile)
 	check("data", cfg.Data)
 	for k, v := range cfg.Headers {
 		check(fmt.Sprintf("header '%s'", k), v)
@@ -592,6 +596,15 @@ func interpolateConfig(chainCtx *ChainContext, cfg *config.ConfigV1) (*config.Co
 			return nil, fmt.Errorf("json: %w", err)
 		}
 		result.JSON = expanded
+	}
+
+	// Interpolate BodyFile
+	if result.BodyFile != "" {
+		expanded, err := chainCtx.ExpandVariables(result.BodyFile)
+		if err != nil {
+			return nil, fmt.Errorf("body_file: %w", err)
+		}
+		result.BodyFile = expanded
 	}
 
 	// Interpolate Data (TCP)

--- a/cli/internal/validation/analyzer.go
+++ b/cli/internal/validation/analyzer.go
@@ -438,6 +438,11 @@ func validateChain(text string, base *config.ConfigV1, chain []config.ChainStep)
 			diags = append(diags, scanForUndefinedRefs(text, step.JSON, definedSteps, step.Name, "json")...)
 		}
 
+		// Check body_file field
+		if step.BodyFile != "" {
+			diags = append(diags, scanForUndefinedRefs(text, step.BodyFile, definedSteps, step.Name, "body_file")...)
+		}
+
 		// Check Variables
 		for k, v := range step.Variables {
 			if s, ok := v.(string); ok {

--- a/cli/internal/validation/validation.go
+++ b/cli/internal/validation/validation.go
@@ -84,10 +84,13 @@ func ValidateRequest(req *domain.Request) []Issue {
 	hasBody := req.Body != nil
 	if req.Metadata["graphql_query"] != "" && hasBody {
 		field := "body"
-		if req.Metadata["body_source"] == "json" {
+		switch req.Metadata["body_source"] {
+		case "json":
 			field = "json"
+		case "body_file":
+			field = "body_file"
 		}
-		add(SeverityError, field, "`graphql` cannot be used with `body` or `json`")
+		add(SeverityError, field, "`graphql` cannot be used with `body`, `body_file`, or `json`")
 	}
 
 	return issues

--- a/docs/topics/config.md
+++ b/docs/topics/config.md
@@ -68,8 +68,19 @@ These are mutually exclusive — use only one:
 | Field | Type | Description |
 |---|---|---|
 | `body` | map | JSON object body |
+| `body_file` | string | Path to a raw request body file, resolved relative to the request file |
 | `json` | string | Raw JSON string body |
 | `form` | map | Form-encoded body |
+
+Use `body_file` for large payloads, exact text payloads, generated fixtures, or gRPC JSON request messages that should live outside YAML:
+
+```yaml
+yapi: v1
+url: https://api.example.com/import
+method: POST
+content_type: application/json
+body_file: ./fixtures/import.json
+```
 
 ## Response Processing
 

--- a/docs/topics/protocols.md
+++ b/docs/topics/protocols.md
@@ -21,6 +21,16 @@ expect:
   status: 201
 ```
 
+Use `body_file` when the payload should live outside YAML:
+
+```yaml
+yapi: v1
+url: https://api.example.com/users
+method: POST
+content_type: application/json
+body_file: ./fixtures/create-user.json
+```
+
 ### Form Data
 
 ```yaml
@@ -67,6 +77,16 @@ rpc: SayHello
 
 body:
   name: "World"
+```
+
+For larger gRPC JSON request messages, use a body file:
+
+```yaml
+yapi: v1
+url: grpc://localhost:50051
+service: helloworld.Greeter
+rpc: SayHello
+body_file: ./fixtures/say-hello.json
 ```
 
 ### With Proto Files

--- a/docs/topics/send.md
+++ b/docs/topics/send.md
@@ -13,8 +13,19 @@ yapi send https://httpbin.org/post '{"hello":"world"}'
 ## Method Detection
 
 - **No body**: defaults to GET
-- **Body provided**: defaults to POST
+- **Body or `--body-file` provided**: defaults to POST
 - **Override with -X**: `yapi send -X PUT https://api.example.com/users/1 '{"name":"Bob"}'`
+
+## Body Files
+
+Read the request body from a file with `--body-file`:
+
+```bash
+yapi send https://httpbin.org/post --body-file ./payload.json \
+  -H "Content-Type: application/json"
+```
+
+`--body-file` is mutually exclusive with the positional body argument.
 
 ## Headers
 
@@ -66,6 +77,10 @@ yapi send https://jsonplaceholder.typicode.com/posts/1
 
 # POST with JSON body
 yapi send https://httpbin.org/post '{"key":"value"}'
+
+# POST with body from file
+yapi send https://httpbin.org/post --body-file ./payload.json \
+  -H "Content-Type: application/json"
 
 # PUT with headers
 yapi send -X PUT https://api.example.com/items/1 '{"name":"updated"}' \


### PR DESCRIPTION
## Summary
- Add `body_file` to v1 configs for raw HTTP/gRPC request payloads resolved relative to the request file.
- Add `yapi send --body-file` for one-off requests and update CLI completions/docs.
- Cover file body loading, mutual exclusion, and command flag registration with tests.

## Testing
- `make sync-docs && make test`