### PR TITLE
fix(cli): Rename 'body_file' to 'request_body_fixture_file' in anticipation of an analogous response body field.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PAT }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_API_HOST: https://us.i.posthog.com
-          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
 
       - uses: ./.github/actions/setup-vscode-extension
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,4 +28,5 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GITHUB_PAT: ${{ secrets.HOMEBREW_GITHUB_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,6 @@ jobs:
         with:
           go-version: stable
 
-      - name: Check required secrets
-        run: |
-          if [ -z "${{ secrets.POSTHOG_API_KEY }}" ]; then
-            echo "Error: POSTHOG_API_KEY secret is not set"
-            exit 1
-          fi
-
       - name: Sync docs for embed
         run: make sync-docs
 
@@ -36,21 +29,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PAT }}
-          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          POSTHOG_API_HOST: https://us.i.posthog.com
-
-      - uses: ./.github/actions/setup-vscode-extension
-
-      - name: Package VS Code extension
-        run: pnpm package:extension
-
-      - name: Upload VS Code extension to release
-        run: |
-          VSIX_FILE=$(ls integrations/vscode/*.vsix 2>/dev/null | head -1)
-          if [ -z "$VSIX_FILE" ]; then
-            echo "Error: No .vsix file found. Did the build step succeed?"
-            exit 1
-          fi
-          gh release upload "${{ github.ref_name }}" "$VSIX_FILE" --clobber
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,24 +37,6 @@ changelog:
       - "^chore:"
       - "^[release]:"
 
-aurs:
-  - name: yapi-bin
-    ids: [yapi_archive]
-    homepage: "https://yapi.run/"
-    description: "The API client that lives in your terminal (and your git repo)"
-    license: "MIT"
-    maintainers:
-      - "Jamie Pond <yapi@pond.audio>"
-    private_key: "{{ .Env.AUR_SSH_KEY }}"
-    git_url: "ssh://aur@aur.archlinux.org/yapi-bin.git"
-    provides:
-      - yapi
-    conflicts:
-      - yapi
-    package: |-
-      install -Dm755 "./yapi" "${pkgdir}/usr/bin/yapi"
-      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/yapi/LICENSE"
-
 homebrew_casks:
   - name: yapi
     description: "CLI-first, offline-first, git-friendly API client for HTTP, gRPC, and TCP"
@@ -71,6 +53,6 @@ homebrew_casks:
         yapi
       For more information: https://github.com/jamierpond/yapi
     repository:
-      owner: jamierpond
-      name: homebrew-yapi
+      owner: prism-data
+      name: homebrew-prism
       branch: main

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,3 +56,4 @@ homebrew_casks:
       owner: prism-data
       name: homebrew-prism
       branch: main
+      token: "{{ .Env.HOMEBREW_GITHUB_PAT }}"

--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ yapi: v1
 url: grpc://localhost:50051
 service: helloworld.Greeter
 rpc: SayHello
+headers:
+  authorization: Bearer ${TOKEN}
+  x-tenant-id: ${TENANT_ID}
 
 body:
   name: "yapi User"

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ yapi send https://jsonplaceholder.typicode.com/posts/1
 # POST with JSON body (method auto-detected when body is provided)
 yapi send https://httpbin.org/post '{"title":"Hello from yapi"}'
 
+# POST with body from file
+yapi send https://httpbin.org/post --body-file ./payload.json \
+  -H 'Content-Type: application/json'
+
 # Explicit method, custom headers
 yapi send -X PUT https://httpbin.org/put '{"updated":true}' \
   -H 'Authorization: Bearer my-token'
@@ -161,6 +165,7 @@ yapi send 'tcp://tcpbin.com:4242' 'Hello from yapi!'
 **Flags:**
 - `-X, --method` - HTTP method (default: GET, or POST if body is provided)
 - `-H, --header` - Custom headers (repeatable, e.g. `-H 'Key: Value'`)
+- `--body-file` - Read request body from a file
 - `-v, --verbose` - Show request details, timing, and response headers
 - `--json` - Output full result as JSON with metadata
 - `--jq` - Apply a JQ filter to the response
@@ -269,6 +274,16 @@ body:
   tags:
     - cli
     - testing
+```
+
+For larger or generated payloads, keep the body in a separate file:
+
+```yaml
+yapi: v1
+url: https://api.example.com/posts
+method: POST
+content_type: application/json
+body_file: ./fixtures/create-post.json
 ```
 
 ### 4\. Advanced Assertions

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ yapi send https://jsonplaceholder.typicode.com/posts/1
 yapi send https://httpbin.org/post '{"title":"Hello from yapi"}'
 
 # POST with body from file
-yapi send https://httpbin.org/post --body-file ./payload.json \
+yapi send https://httpbin.org/post --request-body-fixture-file ./payload.json \
   -H 'Content-Type: application/json'
 
 # Explicit method, custom headers
@@ -165,7 +165,7 @@ yapi send 'tcp://tcpbin.com:4242' 'Hello from yapi!'
 **Flags:**
 - `-X, --method` - HTTP method (default: GET, or POST if body is provided)
 - `-H, --header` - Custom headers (repeatable, e.g. `-H 'Key: Value'`)
-- `--body-file` - Read request body from a file
+- `--request-body-fixture-file` - Read request body from a file
 - `-v, --verbose` - Show request details, timing, and response headers
 - `--json` - Output full result as JSON with metadata
 - `--jq` - Apply a JQ filter to the response
@@ -283,7 +283,7 @@ yapi: v1
 url: https://api.example.com/posts
 method: POST
 content_type: application/json
-body_file: ./fixtures/create-post.json
+request_body_fixture_file: ./fixtures/create-post.json
 ```
 
 ### 4\. Advanced Assertions

--- a/cli/cmd/yapi/send.go
+++ b/cli/cmd/yapi/send.go
@@ -13,6 +13,7 @@ import (
 	"yapi.run/cli/internal/executor"
 	"yapi.run/cli/internal/output"
 	"yapi.run/cli/internal/runner"
+	"yapi.run/cli/internal/vars"
 )
 
 func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
@@ -90,6 +91,12 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read body-file %q: %w", bodyFile, err)
 		}
+		// Expand environment variables in body file contents
+		expanded, err := vars.ExpandString(string(bodyBytes), vars.EnvResolver)
+		if err != nil {
+			return fmt.Errorf("body-file %q: %w", bodyFile, err)
+		}
+		bodyBytes = []byte(expanded)
 		req.Body = bytes.NewReader(bodyBytes)
 		req.Metadata["body_source"] = "body_file"
 		bodyLog = fmt.Sprintf("<body_file: %s (%d bytes)>", bodyFile, len(bodyBytes))

--- a/cli/cmd/yapi/send.go
+++ b/cli/cmd/yapi/send.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,6 +28,10 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	jqFilter, _ := cmd.Flags().GetString("jq")
+	bodyFile, _ := cmd.Flags().GetString("body-file")
+	if body != "" && bodyFile != "" {
+		return fmt.Errorf("positional body and --body-file are mutually exclusive")
+	}
 
 	log := NewLogger(verbose)
 
@@ -33,9 +39,10 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	transport := domain.DetectTransport(url, false)
 
 	// Default method: POST if body provided, GET otherwise (HTTP only)
+	bodyProvided := body != "" || bodyFile != ""
 	if method == "" {
 		if transport == constants.TransportHTTP {
-			if body != "" {
+			if bodyProvided {
 				method = constants.MethodPOST
 			} else {
 				method = constants.MethodGET
@@ -63,6 +70,7 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Set body
+	bodyLog := body
 	if body != "" {
 		req.Body = strings.NewReader(body)
 
@@ -77,6 +85,15 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+	if bodyFile != "" {
+		bodyBytes, err := os.ReadFile(bodyFile) // #nosec G304 -- body-file is an explicit user-provided request payload path
+		if err != nil {
+			return fmt.Errorf("failed to read body-file %q: %w", bodyFile, err)
+		}
+		req.Body = bytes.NewReader(bodyBytes)
+		req.Metadata["body_source"] = "body_file"
+		bodyLog = fmt.Sprintf("<body_file: %s (%d bytes)>", bodyFile, len(bodyBytes))
+	}
 
 	// Set transport metadata
 	req.Metadata["transport"] = transport
@@ -86,7 +103,9 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 
 	// TCP-specific metadata defaults
 	if transport == constants.TransportTCP {
-		req.Metadata["data"] = body
+		if bodyFile == "" {
+			req.Metadata["data"] = body
+		}
 		req.Metadata["encoding"] = "text"
 		req.Metadata["read_timeout"] = "5"
 		req.Metadata["idle_timeout"] = "500"
@@ -98,7 +117,7 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Verbose("Transport: %s", transport)
-	log.Request(method, url, req.Headers, body)
+	log.Request(method, url, req.Headers, bodyLog)
 
 	// Get executor
 	exec, err := executor.GetTransport(transport, app.httpClient)

--- a/cli/cmd/yapi/send.go
+++ b/cli/cmd/yapi/send.go
@@ -29,9 +29,9 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	jqFilter, _ := cmd.Flags().GetString("jq")
-	bodyFile, _ := cmd.Flags().GetString("body-file")
-	if body != "" && bodyFile != "" {
-		return fmt.Errorf("positional body and --body-file are mutually exclusive")
+	requestBodyFixtureFile, _ := cmd.Flags().GetString("request-body-fixture-file")
+	if body != "" && requestBodyFixtureFile != "" {
+		return fmt.Errorf("positional body and --request-body-fixture-file are mutually exclusive")
 	}
 
 	log := NewLogger(verbose)
@@ -40,7 +40,7 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 	transport := domain.DetectTransport(url, false)
 
 	// Default method: POST if body provided, GET otherwise (HTTP only)
-	bodyProvided := body != "" || bodyFile != ""
+	bodyProvided := body != "" || requestBodyFixtureFile != ""
 	if method == "" {
 		if transport == constants.TransportHTTP {
 			if bodyProvided {
@@ -86,20 +86,20 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	if bodyFile != "" {
-		bodyBytes, err := os.ReadFile(bodyFile) // #nosec G304 -- body-file is an explicit user-provided request payload path
+	if requestBodyFixtureFile != "" {
+		bodyBytes, err := os.ReadFile(requestBodyFixtureFile) // #nosec G304 -- request-body-fixture-file is an explicit user-provided request payload path
 		if err != nil {
-			return fmt.Errorf("failed to read body-file %q: %w", bodyFile, err)
+			return fmt.Errorf("failed to read request-body-fixture-file %q: %w", requestBodyFixtureFile, err)
 		}
 		// Expand environment variables in body file contents
 		expanded, err := vars.ExpandString(string(bodyBytes), vars.EnvResolver)
 		if err != nil {
-			return fmt.Errorf("body-file %q: %w", bodyFile, err)
+			return fmt.Errorf("request-body-fixture-file %q: %w", requestBodyFixtureFile, err)
 		}
 		bodyBytes = []byte(expanded)
 		req.Body = bytes.NewReader(bodyBytes)
-		req.Metadata["body_source"] = "body_file"
-		bodyLog = fmt.Sprintf("<body_file: %s (%d bytes)>", bodyFile, len(bodyBytes))
+		req.Metadata["body_source"] = "request-body-fixture-file"
+		bodyLog = fmt.Sprintf("<request-body-fixture-file: %s (%d bytes)>", requestBodyFixtureFile, len(bodyBytes))
 	}
 
 	// Set transport metadata
@@ -110,7 +110,7 @@ func (app *rootCommand) sendE(cmd *cobra.Command, args []string) error {
 
 	// TCP-specific metadata defaults
 	if transport == constants.TransportTCP {
-		if bodyFile == "" {
+		if requestBodyFixtureFile == "" {
 			req.Metadata["data"] = body
 		}
 		req.Metadata["encoding"] = "text"

--- a/cli/internal/cli/commands/commands.go
+++ b/cli/internal/cli/commands/commands.go
@@ -177,6 +177,7 @@ var cmdManifest = []CommandSpec{
 		Flags: []FlagSpec{
 			{Name: "method", Shorthand: "X", Type: "string", Default: "", Usage: "HTTP method (default: GET, or POST if body is provided)"},
 			{Name: "header", Shorthand: "H", Type: "stringSlice", Default: nil, Usage: "Custom headers (e.g. -H 'Content-Type: application/json')"},
+			{Name: "body-file", Type: "string", Default: "", Usage: "Read request body from a file"},
 			{Name: "verbose", Shorthand: "v", Type: "bool", Default: false, Usage: "Show verbose output (request details, timing, headers)"},
 			{Name: "json", Type: "bool", Default: false, Usage: "Output result as JSON with full metadata"},
 			{Name: "jq", Type: "string", Default: "", Usage: "JQ filter to apply to the response"},

--- a/cli/internal/cli/commands/commands.go
+++ b/cli/internal/cli/commands/commands.go
@@ -177,7 +177,7 @@ var cmdManifest = []CommandSpec{
 		Flags: []FlagSpec{
 			{Name: "method", Shorthand: "X", Type: "string", Default: "", Usage: "HTTP method (default: GET, or POST if body is provided)"},
 			{Name: "header", Shorthand: "H", Type: "stringSlice", Default: nil, Usage: "Custom headers (e.g. -H 'Content-Type: application/json')"},
-			{Name: "body-file", Type: "string", Default: "", Usage: "Read request body from a file"},
+			{Name: "request-body-fixture-file", Type: "string", Default: "", Usage: "Read request body from a file"},
 			{Name: "verbose", Shorthand: "v", Type: "bool", Default: false, Usage: "Show verbose output (request details, timing, headers)"},
 			{Name: "json", Type: "bool", Default: false, Usage: "Output result as JSON with full metadata"},
 			{Name: "jq", Type: "string", Default: "", Usage: "JQ filter to apply to the response"},

--- a/cli/internal/cli/commands/commands_test.go
+++ b/cli/internal/cli/commands/commands_test.go
@@ -98,6 +98,24 @@ func TestBuildRoot(t *testing.T) {
 	}
 }
 
+func TestSendCommandHasBodyFileFlag(t *testing.T) {
+	var sendSpec *CommandSpec
+	for i, spec := range cmdManifest {
+		if spec.Use == "send <url> [body]" {
+			sendSpec = &cmdManifest[i]
+			break
+		}
+	}
+	if sendSpec == nil {
+		t.Fatal("send command not found in manifest")
+	}
+
+	cmd := BuildCommand(*sendSpec)
+	if cmd.Flags().Lookup("body-file") == nil {
+		t.Fatal("send command missing body-file flag")
+	}
+}
+
 // Helper function to find a command by name
 func findCommandByName(root *cobra.Command, name string) *cobra.Command {
 	for _, cmd := range root.Commands() {

--- a/cli/internal/cli/commands/commands_test.go
+++ b/cli/internal/cli/commands/commands_test.go
@@ -98,7 +98,7 @@ func TestBuildRoot(t *testing.T) {
 	}
 }
 
-func TestSendCommandHasBodyFileFlag(t *testing.T) {
+func TestSendCommandHasRequestBodyFixtureFileFlag(t *testing.T) {
 	var sendSpec *CommandSpec
 	for i, spec := range cmdManifest {
 		if spec.Use == "send <url> [body]" {
@@ -111,8 +111,8 @@ func TestSendCommandHasBodyFileFlag(t *testing.T) {
 	}
 
 	cmd := BuildCommand(*sendSpec)
-	if cmd.Flags().Lookup("body-file") == nil {
-		t.Fatal("send command missing body-file flag")
+	if cmd.Flags().Lookup("request-body-fixture-file") == nil {
+		t.Fatal("send command missing request-body-fixture-file flag")
 	}
 }
 

--- a/cli/internal/config/loader.go
+++ b/cli/internal/config/loader.go
@@ -100,6 +100,7 @@ func parseV1WithOptions(data []byte, configPath string, resolver vars.Resolver, 
 	if err := yaml.Unmarshal(data, &v1); err != nil {
 		return nil, err
 	}
+	v1.configPath = configPath
 
 	// Merge with environment defaults if provided
 	if defaults != nil {

--- a/cli/internal/config/loader_test.go
+++ b/cli/internal/config/loader_test.go
@@ -171,6 +171,64 @@ headers:
 	}
 }
 
+func TestLoadFromStringWithPath_BodyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.MkdirAll(tmpDir+"/fixtures", 0750); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"name":"from-file","enabled":true}`
+	if err := os.WriteFile(tmpDir+"/fixtures/payload.json", []byte(payload), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	yapiContent := `yapi: v1
+url: https://example.com/create
+method: POST
+content_type: application/json
+body_file: fixtures/payload.json`
+	yapiPath := tmpDir + "/request.yapi.yml"
+
+	result, err := LoadFromStringWithPath(yapiContent, yapiPath, nil, nil)
+	if err != nil {
+		t.Fatalf("LoadFromStringWithPath() failed: %v", err)
+	}
+	if result == nil || result.Request == nil {
+		t.Fatal("LoadFromStringWithPath() returned nil result or request")
+	}
+
+	bodyBytes, err := io.ReadAll(result.Request.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	if string(bodyBytes) != payload {
+		t.Errorf("body = %q, want %q", string(bodyBytes), payload)
+	}
+	if result.Request.Headers["Content-Type"] != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", result.Request.Headers["Content-Type"])
+	}
+	if result.Request.Metadata["body_source"] != "body_file" {
+		t.Errorf("body_source = %q, want body_file", result.Request.Metadata["body_source"])
+	}
+}
+
+func TestLoadFromStringWithPath_BodyFileMutuallyExclusive(t *testing.T) {
+	tmpDir := t.TempDir()
+	yapiContent := `yapi: v1
+url: https://example.com/create
+method: POST
+body_file: payload.json
+json: '{"name":"inline"}'`
+
+	_, err := LoadFromStringWithPath(yapiContent, tmpDir+"/request.yapi.yml", nil, nil)
+	if err == nil {
+		t.Fatal("LoadFromStringWithPath() should have failed")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive error", err)
+	}
+}
+
 func TestLoadFromStringWithPath_EnvFiles_MultipleFiles(t *testing.T) {
 	// Create a temporary directory for our test files
 	tmpDir, err := os.MkdirTemp("", "yapi-envfiles-multi-test-*")

--- a/cli/internal/config/loader_test.go
+++ b/cli/internal/config/loader_test.go
@@ -186,7 +186,7 @@ func TestLoadFromStringWithPath_BodyFile(t *testing.T) {
 url: https://example.com/create
 method: POST
 content_type: application/json
-body_file: fixtures/payload.json`
+request_body_fixture_file: fixtures/payload.json`
 	yapiPath := tmpDir + "/request.yapi.yml"
 
 	result, err := LoadFromStringWithPath(yapiContent, yapiPath, nil, nil)
@@ -207,8 +207,8 @@ body_file: fixtures/payload.json`
 	if result.Request.Headers["Content-Type"] != "application/json" {
 		t.Errorf("Content-Type = %q, want application/json", result.Request.Headers["Content-Type"])
 	}
-	if result.Request.Metadata["body_source"] != "body_file" {
-		t.Errorf("body_source = %q, want body_file", result.Request.Metadata["body_source"])
+	if result.Request.Metadata["body_source"] != "request_body_fixture_file" {
+		t.Errorf("body_source = %q, want request_body_fixture_file", result.Request.Metadata["body_source"])
 	}
 }
 
@@ -217,7 +217,7 @@ func TestLoadFromStringWithPath_BodyFileMutuallyExclusive(t *testing.T) {
 	yapiContent := `yapi: v1
 url: https://example.com/create
 method: POST
-body_file: payload.json
+request_body_fixture_file: payload.json
 json: '{"name":"inline"}'`
 
 	_, err := LoadFromStringWithPath(yapiContent, tmpDir+"/request.yapi.yml", nil, nil)

--- a/cli/internal/config/v1.go
+++ b/cli/internal/config/v1.go
@@ -115,7 +115,8 @@ type ConfigV1 struct {
 	// Chain allows executing multiple dependent requests
 	Chain []ChainStep `yaml:"chain,omitempty"`
 
-	configPath string `yaml:"-"` // Path to this config file for resolving relative files
+	configPath string        `yaml:"-"` // Path to this config file for resolving relative files
+	resolver   vars.Resolver `yaml:"-"` // Resolver for variable expansion (used by prepareBody for body_file contents)
 }
 
 // WaitFor defines polling behavior for a request
@@ -306,12 +307,14 @@ func (a *AssertionSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // ToDomain converts V1 YAML to the Canonical Config
 func (c *ConfigV1) ToDomain() (*domain.Request, error) {
 	c.expandEnvVars()
+	c.resolver = vars.EnvResolver
 	return c.toDomainInternal()
 }
 
 // ToDomainWithResolver converts V1 YAML using a custom resolver for variable expansion
 func (c *ConfigV1) ToDomainWithResolver(resolver vars.Resolver) (*domain.Request, error) {
 	c.ExpandWithResolver(resolver)
+	c.resolver = resolver
 	return c.toDomainInternal()
 }
 
@@ -353,6 +356,11 @@ func (c *ConfigV1) toDomainInternal() (*domain.Request, error) {
 // expandEnvVars expands environment variables in all string fields using reflection
 func (c *ConfigV1) expandEnvVars() {
 	vars.ExpandAll(c, vars.EnvResolver)
+}
+
+// SetResolver sets the variable resolver for body_file content expansion.
+func (c *ConfigV1) SetResolver(resolver vars.Resolver) {
+	c.resolver = resolver
 }
 
 // ExpandWithResolver expands environment variables using a custom resolver
@@ -402,6 +410,14 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 		bodyBytes, err := os.ReadFile(bodyPath) // #nosec G304 -- body_file is an explicit user-provided request payload path
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to read body_file %q: %w", c.BodyFile, err)
+		}
+		// Expand variables in body file contents
+		if c.resolver != nil {
+			expanded, err := vars.ExpandString(string(bodyBytes), c.resolver)
+			if err != nil {
+				return nil, "", fmt.Errorf("body_file %q: %w", c.BodyFile, err)
+			}
+			bodyBytes = []byte(expanded)
 		}
 		return bytes.NewReader(bodyBytes), "body_file", nil
 	}

--- a/cli/internal/config/v1.go
+++ b/cli/internal/config/v1.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"mime/multipart"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -26,6 +28,7 @@ var knownV1Keys = map[string]bool{
 	"content_type":     true,
 	"headers":          true,
 	"body":             true,
+	"body_file":        true,
 	"json":             true,
 	"form":             true,
 	"query":            true,
@@ -74,8 +77,9 @@ type ConfigV1 struct {
 	ContentType    string            `yaml:"content_type,omitempty"`
 	Headers        map[string]string `yaml:"headers,omitempty"`
 	Body           map[string]any    `yaml:"body,omitempty"`
-	JSON           string            `yaml:"json,omitempty"` // Raw JSON override
-	Form           map[string]string `yaml:"form,omitempty"` // Form data (application/x-www-form-urlencoded or multipart/form-data)
+	BodyFile       string            `yaml:"body_file,omitempty"` // Path to raw request body file
+	JSON           string            `yaml:"json,omitempty"`      // Raw JSON override
+	Form           map[string]string `yaml:"form,omitempty"`      // Form data (application/x-www-form-urlencoded or multipart/form-data)
 	Query          map[string]string `yaml:"query,omitempty"`
 	Graphql        string            `yaml:"graphql,omitempty"`   // GraphQL query/mutation
 	Variables      map[string]any    `yaml:"variables,omitempty"` // GraphQL variables
@@ -110,6 +114,8 @@ type ConfigV1 struct {
 
 	// Chain allows executing multiple dependent requests
 	Chain []ChainStep `yaml:"chain,omitempty"`
+
+	configPath string `yaml:"-"` // Path to this config file for resolving relative files
 }
 
 // WaitFor defines polling behavior for a request
@@ -146,6 +152,7 @@ func (c *ConfigV1) Merge(step ChainStep) ConfigV1 {
 	m.Path = utils.Coalesce(step.Path, c.Path)
 	m.Method = utils.Coalesce(step.Method, c.Method)
 	m.ContentType = utils.Coalesce(step.ContentType, c.ContentType)
+	m.BodyFile = utils.Coalesce(step.BodyFile, c.BodyFile)
 	m.JSON = utils.Coalesce(step.JSON, c.JSON)
 	m.Graphql = utils.Coalesce(step.Graphql, c.Graphql)
 	m.Service = utils.Coalesce(step.Service, c.Service)
@@ -204,6 +211,7 @@ func (c *ConfigV1) MergeWithDefaults(defaults ConfigV1) ConfigV1 {
 	m.Path = utils.Coalesce(c.Path, defaults.Path)
 	m.Method = utils.Coalesce(c.Method, defaults.Method)
 	m.ContentType = utils.Coalesce(c.ContentType, defaults.ContentType)
+	m.BodyFile = utils.Coalesce(c.BodyFile, defaults.BodyFile)
 	m.JSON = utils.Coalesce(c.JSON, defaults.JSON)
 	m.Graphql = utils.Coalesce(c.Graphql, defaults.Graphql)
 	m.Service = utils.Coalesce(c.Service, defaults.Service)
@@ -256,6 +264,7 @@ func (c *ConfigV1) MergeWithDefaults(defaults ConfigV1) ConfigV1 {
 	if len(c.EnvFiles) > 0 {
 		m.EnvFiles = c.EnvFiles
 	}
+	m.configPath = c.configPath
 
 	return m
 }
@@ -366,6 +375,9 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 	if c.JSON != "" {
 		bodyFieldCount++
 	}
+	if c.BodyFile != "" {
+		bodyFieldCount++
+	}
 	if len(c.Body) > 0 {
 		bodyFieldCount++
 	}
@@ -373,7 +385,7 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 		bodyFieldCount++
 	}
 	if bodyFieldCount > 1 {
-		return nil, "", fmt.Errorf("`body`, `json`, and `form` are mutually exclusive")
+		return nil, "", fmt.Errorf("`body`, `body_file`, `json`, and `form` are mutually exclusive")
 	}
 
 	// Handle JSON string
@@ -382,6 +394,16 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 			c.ContentType = "application/json"
 		}
 		return strings.NewReader(c.JSON), "json", nil
+	}
+
+	// Handle raw body file
+	if c.BodyFile != "" {
+		bodyPath := c.resolveConfigRelativePath(c.BodyFile)
+		bodyBytes, err := os.ReadFile(bodyPath) // #nosec G304 -- body_file is an explicit user-provided request payload path
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read body_file %q: %w", c.BodyFile, err)
+		}
+		return bytes.NewReader(bodyBytes), "body_file", nil
 	}
 
 	// Handle JSON object
@@ -432,6 +454,13 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 	}
 
 	return nil, "", nil
+}
+
+func (c *ConfigV1) resolveConfigRelativePath(path string) string {
+	if path == "" || filepath.IsAbs(path) || c.configPath == "" {
+		return path
+	}
+	return filepath.Join(filepath.Dir(c.configPath), path)
 }
 
 // buildURL constructs the final URL with path and query parameters

--- a/cli/internal/config/v1.go
+++ b/cli/internal/config/v1.go
@@ -21,38 +21,38 @@ import (
 // knownV1Keys is the set of valid keys for v1 config files.
 // Must be kept in sync with ConfigV1 struct yaml tags.
 var knownV1Keys = map[string]bool{
-	"yapi":             true,
-	"url":              true,
-	"path":             true,
-	"method":           true,
-	"content_type":     true,
-	"headers":          true,
-	"body":             true,
-	"body_file":        true,
-	"json":             true,
-	"form":             true,
-	"query":            true,
-	"graphql":          true,
-	"variables":        true,
-	"service":          true,
-	"rpc":              true,
-	"proto":            true,
-	"proto_path":       true,
-	"data":             true,
-	"encoding":         true,
-	"jq_filter":        true,
-	"insecure":         true,
-	"plaintext":        true,
-	"read_timeout":     true,
-	"idle_timeout":     true,
-	"close_after_send": true,
-	"chain":            true,
-	"expect":           true,
-	"delay":            true,
-	"output_file":      true,
-	"timeout":          true,
-	"env_files":        true,
-	"wait_for":         true,
+	"yapi":                      true,
+	"url":                       true,
+	"path":                      true,
+	"method":                    true,
+	"content_type":              true,
+	"headers":                   true,
+	"body":                      true,
+	"request_body_fixture_file": true,
+	"json":                      true,
+	"form":                      true,
+	"query":                     true,
+	"graphql":                   true,
+	"variables":                 true,
+	"service":                   true,
+	"rpc":                       true,
+	"proto":                     true,
+	"proto_path":                true,
+	"data":                      true,
+	"encoding":                  true,
+	"jq_filter":                 true,
+	"insecure":                  true,
+	"plaintext":                 true,
+	"read_timeout":              true,
+	"idle_timeout":              true,
+	"close_after_send":          true,
+	"chain":                     true,
+	"expect":                    true,
+	"delay":                     true,
+	"output_file":               true,
+	"timeout":                   true,
+	"env_files":                 true,
+	"wait_for":                  true,
 }
 
 // FindUnknownKeys checks a raw map for keys not in knownV1Keys.
@@ -77,9 +77,9 @@ type ConfigV1 struct {
 	ContentType    string            `yaml:"content_type,omitempty"`
 	Headers        map[string]string `yaml:"headers,omitempty"`
 	Body           map[string]any    `yaml:"body,omitempty"`
-	BodyFile       string            `yaml:"body_file,omitempty"` // Path to raw request body file
-	JSON           string            `yaml:"json,omitempty"`      // Raw JSON override
-	Form           map[string]string `yaml:"form,omitempty"`      // Form data (application/x-www-form-urlencoded or multipart/form-data)
+	BodyFile       string            `yaml:"request_body_fixture_file,omitempty"` // Path to raw request body file
+	JSON           string            `yaml:"json,omitempty"`                      // Raw JSON override
+	Form           map[string]string `yaml:"form,omitempty"`                      // Form data (application/x-www-form-urlencoded or multipart/form-data)
 	Query          map[string]string `yaml:"query,omitempty"`
 	Graphql        string            `yaml:"graphql,omitempty"`   // GraphQL query/mutation
 	Variables      map[string]any    `yaml:"variables,omitempty"` // GraphQL variables
@@ -116,7 +116,7 @@ type ConfigV1 struct {
 	Chain []ChainStep `yaml:"chain,omitempty"`
 
 	configPath string        `yaml:"-"` // Path to this config file for resolving relative files
-	resolver   vars.Resolver `yaml:"-"` // Resolver for variable expansion (used by prepareBody for body_file contents)
+	resolver   vars.Resolver `yaml:"-"` // Resolver for variable expansion (used by prepareBody for request_body_fixture_file contents)
 }
 
 // WaitFor defines polling behavior for a request
@@ -358,7 +358,7 @@ func (c *ConfigV1) expandEnvVars() {
 	vars.ExpandAll(c, vars.EnvResolver)
 }
 
-// SetResolver sets the variable resolver for body_file content expansion.
+// SetResolver sets the variable resolver for request_body_fixture_file content expansion.
 func (c *ConfigV1) SetResolver(resolver vars.Resolver) {
 	c.resolver = resolver
 }
@@ -393,7 +393,7 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 		bodyFieldCount++
 	}
 	if bodyFieldCount > 1 {
-		return nil, "", fmt.Errorf("`body`, `body_file`, `json`, and `form` are mutually exclusive")
+		return nil, "", fmt.Errorf("`body`, `request_body_fixture_file`, `json`, and `form` are mutually exclusive")
 	}
 
 	// Handle JSON string
@@ -407,19 +407,19 @@ func (c *ConfigV1) prepareBody() (io.Reader, string, error) {
 	// Handle raw body file
 	if c.BodyFile != "" {
 		bodyPath := c.resolveConfigRelativePath(c.BodyFile)
-		bodyBytes, err := os.ReadFile(bodyPath) // #nosec G304 -- body_file is an explicit user-provided request payload path
+		bodyBytes, err := os.ReadFile(bodyPath) // #nosec G304 -- request_body_fixture_file is an explicit user-provided request payload path
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to read body_file %q: %w", c.BodyFile, err)
+			return nil, "", fmt.Errorf("failed to read request_body_fixture_file %q: %w", c.BodyFile, err)
 		}
 		// Expand variables in body file contents
 		if c.resolver != nil {
 			expanded, err := vars.ExpandString(string(bodyBytes), c.resolver)
 			if err != nil {
-				return nil, "", fmt.Errorf("body_file %q: %w", c.BodyFile, err)
+				return nil, "", fmt.Errorf("request_body_fixture_file %q: %w", c.BodyFile, err)
 			}
 			bodyBytes = []byte(expanded)
 		}
-		return bytes.NewReader(bodyBytes), "body_file", nil
+		return bytes.NewReader(bodyBytes), "request_body_fixture_file", nil
 	}
 
 	// Handle JSON object

--- a/cli/internal/executor/grpc.go
+++ b/cli/internal/executor/grpc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -84,7 +85,7 @@ func GRPCTransport(ctx context.Context, req *domain.Request) (*domain.Response, 
 	handler := grpcurl.NewDefaultEventHandler(respBuf, descSource, formatter, false)
 
 	// Invoke RPC
-	if err := grpcurl.InvokeRPC(ctx, descSource, cc, service+"/"+rpc, nil, handler, reqSupplier); err != nil {
+	if err := grpcurl.InvokeRPC(ctx, descSource, cc, service+"/"+rpc, grpcMetadataHeaders(req.Headers), handler, reqSupplier); err != nil {
 		return nil, fmt.Errorf("failed to invoke gRPC RPC %s/%s: %w", service, rpc, err)
 	}
 
@@ -93,4 +94,22 @@ func GRPCTransport(ctx context.Context, req *domain.Request) (*domain.Response, 
 		Headers:    map[string]string{"Content-Type": "application/json"},
 		Body:       io.NopCloser(respBuf),
 	}, nil
+}
+
+func grpcMetadataHeaders(headers map[string]string) []string {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	metadata := make([]string, 0, len(keys))
+	for _, key := range keys {
+		metadata = append(metadata, fmt.Sprintf("%s: %s", key, headers[key]))
+	}
+	return metadata
 }

--- a/cli/internal/executor/grpc_test.go
+++ b/cli/internal/executor/grpc_test.go
@@ -1,0 +1,31 @@
+package executor
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGRPCMetadataHeaders(t *testing.T) {
+	headers := map[string]string{
+		"x-tenant-id":   "tenant-123",
+		"authorization": "Bearer token",
+		"trace-bin":     "AQIDBA==",
+	}
+
+	got := grpcMetadataHeaders(headers)
+	want := []string{
+		"authorization: Bearer token",
+		"trace-bin: AQIDBA==",
+		"x-tenant-id: tenant-123",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("grpcMetadataHeaders() = %v, want %v", got, want)
+	}
+}
+
+func TestGRPCMetadataHeadersEmpty(t *testing.T) {
+	if got := grpcMetadataHeaders(nil); got != nil {
+		t.Fatalf("grpcMetadataHeaders(nil) = %v, want nil", got)
+	}
+}

--- a/cli/internal/langserver/langserver.go
+++ b/cli/internal/langserver/langserver.go
@@ -434,7 +434,7 @@ var topLevelKeys = []struct {
 	{"url", "The target URL (required)"},
 	{"path", "URL path to append"},
 	{"method", "HTTP method or protocol (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, grpc, tcp)"},
-	{"headers", "HTTP headers as key-value pairs"},
+	{"headers", "HTTP headers or gRPC metadata as key-value pairs"},
 	{"content_type", "Content-Type header value"},
 	{"body", "Request body as key-value pairs"},
 	{"body_file", "Path to a raw request body file"},

--- a/cli/internal/langserver/langserver.go
+++ b/cli/internal/langserver/langserver.go
@@ -437,6 +437,7 @@ var topLevelKeys = []struct {
 	{"headers", "HTTP headers as key-value pairs"},
 	{"content_type", "Content-Type header value"},
 	{"body", "Request body as key-value pairs"},
+	{"body_file", "Path to a raw request body file"},
 	{"json", "Raw JSON string for request body"},
 	{"query", "Query parameters as key-value pairs"},
 	{"graphql", "GraphQL query or mutation (multiline string)"},

--- a/cli/internal/langserver/langserver.go
+++ b/cli/internal/langserver/langserver.go
@@ -437,7 +437,7 @@ var topLevelKeys = []struct {
 	{"headers", "HTTP headers or gRPC metadata as key-value pairs"},
 	{"content_type", "Content-Type header value"},
 	{"body", "Request body as key-value pairs"},
-	{"body_file", "Path to a raw request body file"},
+	{"request_body_fixture_file", "Path to a raw request body file"},
 	{"json", "Raw JSON string for request body"},
 	{"query", "Query parameters as key-value pairs"},
 	{"graphql", "GraphQL query or mutation (multiline string)"},

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -375,6 +375,7 @@ func RunChain(ctx context.Context, factory ExecutorFactory, base *config.ConfigV
 		}
 
 		// 4. Convert to domain request (handles ALL transports: HTTP, TCP, gRPC, GraphQL)
+		interpolatedConfig.SetResolver(chainCtx.Resolve)
 		req, err := interpolatedConfig.ToDomain()
 		if err != nil {
 			return nil, fmt.Errorf("step '%s': %w", step.Name, err)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -467,6 +467,9 @@ func logResolvedConfig(stepNum int, stepName string, cfg *config.ConfigV1) {
 	if cfg.JSON != "" {
 		fmt.Fprintf(os.Stderr, "[VERBOSE]   JSON: %s\n", truncateStr(cfg.JSON))
 	}
+	if cfg.BodyFile != "" {
+		fmt.Fprintf(os.Stderr, "[VERBOSE]   BodyFile: %s\n", cfg.BodyFile)
+	}
 	if cfg.Data != "" {
 		fmt.Fprintf(os.Stderr, "[VERBOSE]   Data: %s\n", truncateStr(cfg.Data))
 	}
@@ -496,6 +499,7 @@ func warnBareChainRefsInConfig(stepName string, cfg *config.ConfigV1) {
 	check("url", cfg.URL)
 	check("path", cfg.Path)
 	check("json", cfg.JSON)
+	check("body_file", cfg.BodyFile)
 	check("data", cfg.Data)
 	for k, v := range cfg.Headers {
 		check(fmt.Sprintf("header '%s'", k), v)
@@ -592,6 +596,15 @@ func interpolateConfig(chainCtx *ChainContext, cfg *config.ConfigV1) (*config.Co
 			return nil, fmt.Errorf("json: %w", err)
 		}
 		result.JSON = expanded
+	}
+
+	// Interpolate BodyFile
+	if result.BodyFile != "" {
+		expanded, err := chainCtx.ExpandVariables(result.BodyFile)
+		if err != nil {
+			return nil, fmt.Errorf("body_file: %w", err)
+		}
+		result.BodyFile = expanded
 	}
 
 	// Interpolate Data (TCP)

--- a/cli/internal/runner/runner.go
+++ b/cli/internal/runner/runner.go
@@ -500,7 +500,7 @@ func warnBareChainRefsInConfig(stepName string, cfg *config.ConfigV1) {
 	check("url", cfg.URL)
 	check("path", cfg.Path)
 	check("json", cfg.JSON)
-	check("body_file", cfg.BodyFile)
+	check("request_body_fixture_file", cfg.BodyFile)
 	check("data", cfg.Data)
 	for k, v := range cfg.Headers {
 		check(fmt.Sprintf("header '%s'", k), v)
@@ -603,7 +603,7 @@ func interpolateConfig(chainCtx *ChainContext, cfg *config.ConfigV1) (*config.Co
 	if result.BodyFile != "" {
 		expanded, err := chainCtx.ExpandVariables(result.BodyFile)
 		if err != nil {
-			return nil, fmt.Errorf("body_file: %w", err)
+			return nil, fmt.Errorf("request_body_fixture_file: %w", err)
 		}
 		result.BodyFile = expanded
 	}

--- a/cli/internal/validation/analyzer.go
+++ b/cli/internal/validation/analyzer.go
@@ -438,6 +438,11 @@ func validateChain(text string, base *config.ConfigV1, chain []config.ChainStep)
 			diags = append(diags, scanForUndefinedRefs(text, step.JSON, definedSteps, step.Name, "json")...)
 		}
 
+		// Check body_file field
+		if step.BodyFile != "" {
+			diags = append(diags, scanForUndefinedRefs(text, step.BodyFile, definedSteps, step.Name, "body_file")...)
+		}
+
 		// Check Variables
 		for k, v := range step.Variables {
 			if s, ok := v.(string); ok {

--- a/cli/internal/validation/analyzer.go
+++ b/cli/internal/validation/analyzer.go
@@ -438,9 +438,9 @@ func validateChain(text string, base *config.ConfigV1, chain []config.ChainStep)
 			diags = append(diags, scanForUndefinedRefs(text, step.JSON, definedSteps, step.Name, "json")...)
 		}
 
-		// Check body_file field
+		// Check request_body_fixture_file field
 		if step.BodyFile != "" {
-			diags = append(diags, scanForUndefinedRefs(text, step.BodyFile, definedSteps, step.Name, "body_file")...)
+			diags = append(diags, scanForUndefinedRefs(text, step.BodyFile, definedSteps, step.Name, "request_body_fixture_file")...)
 		}
 
 		// Check Variables

--- a/cli/internal/validation/validation.go
+++ b/cli/internal/validation/validation.go
@@ -84,10 +84,13 @@ func ValidateRequest(req *domain.Request) []Issue {
 	hasBody := req.Body != nil
 	if req.Metadata["graphql_query"] != "" && hasBody {
 		field := "body"
-		if req.Metadata["body_source"] == "json" {
+		switch req.Metadata["body_source"] {
+		case "json":
 			field = "json"
+		case "body_file":
+			field = "body_file"
 		}
-		add(SeverityError, field, "`graphql` cannot be used with `body` or `json`")
+		add(SeverityError, field, "`graphql` cannot be used with `body`, `body_file`, or `json`")
 	}
 
 	return issues

--- a/cli/internal/validation/validation.go
+++ b/cli/internal/validation/validation.go
@@ -87,10 +87,10 @@ func ValidateRequest(req *domain.Request) []Issue {
 		switch req.Metadata["body_source"] {
 		case "json":
 			field = "json"
-		case "body_file":
-			field = "body_file"
+		case "request_body_fixture_file":
+			field = "request_body_fixture_file"
 		}
-		add(SeverityError, field, "`graphql` cannot be used with `body`, `body_file`, or `json`")
+		add(SeverityError, field, "`graphql` cannot be used with `body`, `request_body_fixture_file`, or `json`")
 	}
 
 	return issues

--- a/docs/topics/config.md
+++ b/docs/topics/config.md
@@ -53,7 +53,7 @@ Because the request file uses `path: /` instead of a full `url`, yapi resolves i
 | `url` | string | Full request URL |
 | `path` | string | Path appended to environment base URL |
 | `method` | string | HTTP method: GET, POST, PUT, PATCH, DELETE |
-| `headers` | map | Request headers |
+| `headers` | map | HTTP request headers or gRPC metadata |
 | `query` | map | Query parameters |
 | `timeout` | string | Request timeout (e.g., `"4s"`, `"100ms"`) |
 | `delay` | string | Wait before executing (e.g., `"5s"`) |
@@ -106,6 +106,8 @@ body_file: ./fixtures/import.json
 | `proto` | string | Path to .proto file |
 | `proto_path` | string | Proto import path |
 | `plaintext` | bool | No TLS for gRPC |
+
+For gRPC requests, values in `headers` are sent as request metadata. Use lowercase keys for custom metadata, and base64-encoded values for binary metadata keys ending in `-bin`.
 
 ## TCP Fields
 

--- a/docs/topics/config.md
+++ b/docs/topics/config.md
@@ -68,8 +68,19 @@ These are mutually exclusive — use only one:
 | Field | Type | Description |
 |---|---|---|
 | `body` | map | JSON object body |
+| `body_file` | string | Path to a raw request body file, resolved relative to the request file |
 | `json` | string | Raw JSON string body |
 | `form` | map | Form-encoded body |
+
+Use `body_file` for large payloads, exact text payloads, generated fixtures, or gRPC JSON request messages that should live outside YAML:
+
+```yaml
+yapi: v1
+url: https://api.example.com/import
+method: POST
+content_type: application/json
+body_file: ./fixtures/import.json
+```
 
 ## Response Processing
 

--- a/docs/topics/config.md
+++ b/docs/topics/config.md
@@ -68,18 +68,18 @@ These are mutually exclusive — use only one:
 | Field | Type | Description |
 |---|---|---|
 | `body` | map | JSON object body |
-| `body_file` | string | Path to a raw request body file, resolved relative to the request file |
+| `request_body_fixture_file` | string | Path to a raw request body file, resolved relative to the request file |
 | `json` | string | Raw JSON string body |
 | `form` | map | Form-encoded body |
 
-Use `body_file` for large payloads, exact text payloads, generated fixtures, or gRPC JSON request messages that should live outside YAML:
+Use `request_body_fixture_file` for large payloads, exact text payloads, generated fixtures, or gRPC JSON request messages that should live outside YAML:
 
 ```yaml
 yapi: v1
 url: https://api.example.com/import
 method: POST
 content_type: application/json
-body_file: ./fixtures/import.json
+request_body_fixture_file: ./fixtures/import.json
 ```
 
 ## Response Processing

--- a/docs/topics/protocols.md
+++ b/docs/topics/protocols.md
@@ -21,6 +21,16 @@ expect:
   status: 201
 ```
 
+Use `body_file` when the payload should live outside YAML:
+
+```yaml
+yapi: v1
+url: https://api.example.com/users
+method: POST
+content_type: application/json
+body_file: ./fixtures/create-user.json
+```
+
 ### Form Data
 
 ```yaml
@@ -67,6 +77,16 @@ rpc: SayHello
 
 body:
   name: "World"
+```
+
+For larger gRPC JSON request messages, use a body file:
+
+```yaml
+yapi: v1
+url: grpc://localhost:50051
+service: helloworld.Greeter
+rpc: SayHello
+body_file: ./fixtures/say-hello.json
 ```
 
 ### With Proto Files

--- a/docs/topics/protocols.md
+++ b/docs/topics/protocols.md
@@ -89,6 +89,24 @@ rpc: SayHello
 body_file: ./fixtures/say-hello.json
 ```
 
+### Metadata
+
+Use `headers` to send gRPC request metadata:
+
+```yaml
+yapi: v1
+url: grpc://localhost:50051
+service: helloworld.Greeter
+rpc: SayHello
+headers:
+  authorization: Bearer ${TOKEN}
+  x-tenant-id: ${TENANT_ID}
+body:
+  name: "World"
+```
+
+Metadata keys should generally be lowercase. Binary metadata keys ending in `-bin` should use base64-encoded values.
+
 ### With Proto Files
 
 ```yaml

--- a/docs/topics/protocols.md
+++ b/docs/topics/protocols.md
@@ -21,14 +21,14 @@ expect:
   status: 201
 ```
 
-Use `body_file` when the payload should live outside YAML:
+Use `request_body_fixture_file` when the payload should live outside YAML:
 
 ```yaml
 yapi: v1
 url: https://api.example.com/users
 method: POST
 content_type: application/json
-body_file: ./fixtures/create-user.json
+request_body_fixture_file: ./fixtures/create-user.json
 ```
 
 ### Form Data
@@ -86,7 +86,7 @@ yapi: v1
 url: grpc://localhost:50051
 service: helloworld.Greeter
 rpc: SayHello
-body_file: ./fixtures/say-hello.json
+request_body_fixture_file: ./fixtures/say-hello.json
 ```
 
 ### Metadata

--- a/docs/topics/send.md
+++ b/docs/topics/send.md
@@ -13,8 +13,19 @@ yapi send https://httpbin.org/post '{"hello":"world"}'
 ## Method Detection
 
 - **No body**: defaults to GET
-- **Body provided**: defaults to POST
+- **Body or `--body-file` provided**: defaults to POST
 - **Override with -X**: `yapi send -X PUT https://api.example.com/users/1 '{"name":"Bob"}'`
+
+## Body Files
+
+Read the request body from a file with `--body-file`:
+
+```bash
+yapi send https://httpbin.org/post --body-file ./payload.json \
+  -H "Content-Type: application/json"
+```
+
+`--body-file` is mutually exclusive with the positional body argument.
 
 ## Headers
 
@@ -66,6 +77,10 @@ yapi send https://jsonplaceholder.typicode.com/posts/1
 
 # POST with JSON body
 yapi send https://httpbin.org/post '{"key":"value"}'
+
+# POST with body from file
+yapi send https://httpbin.org/post --body-file ./payload.json \
+  -H "Content-Type: application/json"
 
 # PUT with headers
 yapi send -X PUT https://api.example.com/items/1 '{"name":"updated"}' \

--- a/docs/topics/send.md
+++ b/docs/topics/send.md
@@ -13,19 +13,19 @@ yapi send https://httpbin.org/post '{"hello":"world"}'
 ## Method Detection
 
 - **No body**: defaults to GET
-- **Body or `--body-file` provided**: defaults to POST
+- **Body or `--request-body-fixture-file` provided**: defaults to POST
 - **Override with -X**: `yapi send -X PUT https://api.example.com/users/1 '{"name":"Bob"}'`
 
 ## Body Files
 
-Read the request body from a file with `--body-file`:
+Read the request body from a file with `--request-body-fixture-file`:
 
 ```bash
-yapi send https://httpbin.org/post --body-file ./payload.json \
+yapi send https://httpbin.org/post --request-body-fixture-file ./payload.json \
   -H "Content-Type: application/json"
 ```
 
-`--body-file` is mutually exclusive with the positional body argument.
+`--request-body-fixture-file` is mutually exclusive with the positional body argument.
 
 ## Headers
 
@@ -79,7 +79,7 @@ yapi send https://jsonplaceholder.typicode.com/posts/1
 yapi send https://httpbin.org/post '{"key":"value"}'
 
 # POST with body from file
-yapi send https://httpbin.org/post --body-file ./payload.json \
+yapi send https://httpbin.org/post --request-body-fixture-file ./payload.json \
   -H "Content-Type: application/json"
 
 # PUT with headers


### PR DESCRIPTION
This pull requests disambiguates `body_file` / `--body-file` by renaming the field `request_body_fixture_file` / `--request-body-fixture-file` in the anticipation of an analogous fixture file option for validating response bodies.